### PR TITLE
合并 rdo 2014.2.1-2 中的 patch

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,7 +44,6 @@ sys.path = [
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.coverage',
               'sphinx.ext.ifconfig',
-              'sphinx.ext.intersphinx',
               'sphinx.ext.pngmath',
               'sphinx.ext.graphviz',
               'oslosphinx',

--- a/etc/glance-cache.conf
+++ b/etc/glance-cache.conf
@@ -44,9 +44,7 @@ registry_port = 9191
 #                glance.store.rbd.Store,
 #                glance.store.s3.Store,
 #                glance.store.swift.Store,
-#                glance.store.sheepdog.Store,
 #                glance.store.cinder.Store,
-#                glance.store.vmware_datastore.Store,
 
 # ============ Filesystem Store Options ========================
 

--- a/glance/cmd/api.py
+++ b/glance/cmd/api.py
@@ -49,6 +49,7 @@ from glance.common import exception
 from glance.common import wsgi
 from glance import notifier
 from glance.openstack.common import log
+from glance.openstack.common import systemd
 
 CONF = cfg.CONF
 CONF.import_group("profiler", "glance.common.wsgi")
@@ -81,6 +82,7 @@ def main():
 
         server = wsgi.Server()
         server.start(config.load_paste_app('glance-api'), default_port=9292)
+        systemd.notify_once()
         server.wait()
     except exception.WorkerCreationFailure as e:
         fail(2, e)

--- a/glance/cmd/registry.py
+++ b/glance/cmd/registry.py
@@ -44,6 +44,7 @@ from glance.common import config
 from glance.common import wsgi
 from glance import notifier
 from glance.openstack.common import log
+from glance.openstack.common import systemd
 
 CONF = cfg.CONF
 CONF.import_group("profiler", "glance.common.wsgi")
@@ -69,6 +70,7 @@ def main():
         server = wsgi.Server()
         server.start(config.load_paste_app('glance-registry'),
                      default_port=9191)
+        systemd.notify_once()
         server.wait()
     except RuntimeError as e:
         sys.exit("ERROR: %s" % e)

--- a/glance/cmd/scrubber.py
+++ b/glance/cmd/scrubber.py
@@ -35,6 +35,7 @@ from oslo.config import cfg
 
 from glance.common import config
 from glance.openstack.common import log
+from glance.openstack.common import systemd
 from glance import scrubber
 
 
@@ -58,6 +59,7 @@ def main():
         if CONF.daemon:
             server = scrubber.Daemon(CONF.wakeup_time)
             server.start(app)
+            systemd.notify_once()
             server.wait()
         else:
             import eventlet

--- a/glance/common/store_utils.py
+++ b/glance/common/store_utils.py
@@ -38,6 +38,8 @@ store_utils_opts = [
 CONF = cfg.CONF
 CONF.register_opts(store_utils_opts)
 
+RESTRICTED_URI_SCHEMAS = frozenset(['file', 'filesystem', 'swift+config'])
+
 
 def safe_delete_from_backend(context, image_id, location):
     """
@@ -136,8 +138,7 @@ def validate_external_location(uri):
     """
 
     # TODO(zhiyan): This function could be moved to glance_store.
-
-    pieces = urlparse.urlparse(uri)
-    valid_schemes = [scheme for scheme in store_api.get_known_schemes()
-                     if scheme != 'file' and scheme != 'swift+config']
-    return pieces.scheme in valid_schemes
+    # TODO(gm): Use a whitelist of allowed schemes
+    scheme = urlparse.urlparse(uri).scheme
+    return (scheme in store_api.get_known_schemes() and
+            scheme not in RESTRICTED_URI_SCHEMAS)

--- a/glance/common/store_utils.py
+++ b/glance/common/store_utils.py
@@ -16,6 +16,7 @@ import sys
 
 import glance_store as store_api
 from oslo.config import cfg
+import six.moves.urllib.parse as urlparse
 
 from glance.common import utils
 import glance.db as db_api
@@ -119,3 +120,24 @@ def delete_image_location_from_backend(context, image_id, location):
         # such as uploading process failure then we can't use
         # location status mechanism to support image pending delete.
         safe_delete_from_backend(context, image_id, location)
+
+
+def validate_external_location(uri):
+    """
+    Validate if URI of external location are supported.
+
+    Only over non-local store types are OK, i.e. S3, Swift,
+    HTTP. Note the absence of 'file://' for security reasons,
+    see LP bug #942118, 1400966, 'swift+config://' is also
+    absent for security reasons, see LP bug #1334196.
+
+    :param uri: The URI of external image location.
+    :return: Whether given URI of external image location are OK.
+    """
+
+    # TODO(zhiyan): This function could be moved to glance_store.
+
+    pieces = urlparse.urlparse(uri)
+    valid_schemes = [scheme for scheme in store_api.get_known_schemes()
+                     if scheme != 'file' and scheme != 'swift+config']
+    return pieces.scheme in valid_schemes

--- a/glance/openstack/common/systemd.py
+++ b/glance/openstack/common/systemd.py
@@ -1,0 +1,104 @@
+# Copyright 2012-2014 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+Helper module for systemd service readiness notification.
+"""
+
+import os
+import socket
+import sys
+
+from glance.openstack.common import log as logging
+
+
+LOG = logging.getLogger(__name__)
+
+
+def _abstractify(socket_name):
+    if socket_name.startswith('@'):
+        # abstract namespace socket
+        socket_name = '\0%s' % socket_name[1:]
+    return socket_name
+
+
+def _sd_notify(unset_env, msg):
+    notify_socket = os.getenv('NOTIFY_SOCKET')
+    if notify_socket:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        try:
+            sock.connect(_abstractify(notify_socket))
+            sock.sendall(msg)
+            if unset_env:
+                del os.environ['NOTIFY_SOCKET']
+        except EnvironmentError:
+            LOG.debug("Systemd notification failed", exc_info=True)
+        finally:
+            sock.close()
+
+
+def notify():
+    """Send notification to Systemd that service is ready.
+    For details see
+      http://www.freedesktop.org/software/systemd/man/sd_notify.html
+    """
+    _sd_notify(False, 'READY=1')
+
+
+def notify_once():
+    """Send notification once to Systemd that service is ready.
+    Systemd sets NOTIFY_SOCKET environment variable with the name of the
+    socket listening for notifications from services.
+    This method removes the NOTIFY_SOCKET environment variable to ensure
+    notification is sent only once.
+    """
+    _sd_notify(True, 'READY=1')
+
+
+def onready(notify_socket, timeout):
+    """Wait for systemd style notification on the socket.
+
+    :param notify_socket: local socket address
+    :type notify_socket:  string
+    :param timeout:       socket timeout
+    :type timeout:        float
+    :returns:             0 service ready
+                          1 service not ready
+                          2 timeout occured
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    sock.bind(_abstractify(notify_socket))
+    try:
+        msg = sock.recv(512)
+    except socket.timeout:
+        return 2
+    finally:
+        sock.close()
+    if 'READY=1' in msg:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == '__main__':
+    # simple CLI for testing
+    if len(sys.argv) == 1:
+        notify()
+    elif len(sys.argv) >= 2:
+        timeout = float(sys.argv[1])
+        notify_socket = os.getenv('NOTIFY_SOCKET')
+        if notify_socket:
+            retval = onready(notify_socket, timeout)
+            sys.exit(retval)

--- a/glance/tests/functional/v1/test_copy_to_file.py
+++ b/glance/tests/functional/v1/test_copy_to_file.py
@@ -250,7 +250,7 @@ class TestCopyToFile(functional.FunctionalTest):
         response, content = http.request(path, 'POST', headers=headers)
         self.assertEqual(response.status, 400, content)
 
-        expected = 'External sourcing not supported for store \'file\''
+        expected = 'External source are not supported: \'%s\'' % copy_from
         msg = 'expected "%s" in "%s"' % (expected, content)
         self.assertTrue(expected in content, msg)
 
@@ -276,7 +276,7 @@ class TestCopyToFile(functional.FunctionalTest):
         response, content = http.request(path, 'POST', headers=headers)
         self.assertEqual(response.status, 400, content)
 
-        expected = 'External sourcing not supported for store \'swift+config\''
+        expected = 'External source are not supported: \'swift+config://xxx\''
         msg = 'expected "%s" in "%s"' % (expected, content)
         self.assertTrue(expected in content, msg)
 

--- a/glance/tests/functional/v2/test_images.py
+++ b/glance/tests/functional/v2/test_images.py
@@ -16,7 +16,6 @@
 import BaseHTTPServer
 import os
 import signal
-import tempfile
 import uuid
 
 import requests
@@ -47,7 +46,7 @@ def get_handler_class(fixture):
             self.end_headers()
             return
 
-        def log_message(*args, **kwargs):
+        def log_message(self, *args, **kwargs):
             # Override this method to prevent debug output from going
             # to stderr during testing
             return
@@ -75,6 +74,18 @@ class TestImages(functional.FunctionalTest):
         self.cleanup()
         self.api_server.deployment_flavor = 'noauth'
         self.api_server.data_api = 'glance.db.sqlalchemy.api'
+        for i in range(3):
+            ret = http_server("foo_image_id%d" % i, "foo_image%d" % i)
+            setattr(self, 'http_server%d_pid' % i, ret[0])
+            setattr(self, 'http_port%d' % i, ret[1])
+
+    def tearDown(self):
+        for i in range(3):
+            pid = getattr(self, 'http_server%d_pid' % i, None)
+            if pid:
+                os.kill(pid, signal.SIGKILL)
+
+        super(TestImages, self).tearDown()
 
     def _url(self, path):
         return 'http://127.0.0.1:%d%s' % (self.api_port, path)
@@ -329,21 +340,15 @@ class TestImages(functional.FunctionalTest):
         self.assertEqual(413, response.status_code, response.text)
 
         # Adding 3 image locations should fail since configured limit is 2
-        for i in range(3):
-            file_path = os.path.join(self.test_dir, 'fake_image_%i' % i)
-            with open(file_path, 'w') as fap:
-                fap.write('glance')
-
         path = self._url('/v2/images/%s' % image_id)
         media_type = 'application/openstack-images-v2.1-json-patch'
         headers = self._headers({'content-type': media_type})
         changes = []
         for i in range(3):
+            url = ('http://127.0.0.1:%s/foo_image' %
+                   getattr(self, 'http_port%d' % i))
             changes.append({'op': 'add', 'path': '/locations/-',
-                            'value': {'url': 'file://{0}'.format(
-                                os.path.join(self.test_dir,
-                                             'fake_image_%i' % i)),
-                                      'metadata': {}},
+                            'value': {'url': url, 'metadata': {}},
                             })
 
         data = jsonutils.dumps(changes)
@@ -2176,17 +2181,14 @@ class TestImages(functional.FunctionalTest):
         self.assertNotIn('size', image)
         self.assertNotIn('virtual_size', image)
 
-        file_path = os.path.join(self.test_dir, 'fake_image')
-        with open(file_path, 'w') as fap:
-            fap.write('glance')
-
         # Update locations for the queued image
         path = self._url('/v2/images/%s' % image_id)
         media_type = 'application/openstack-images-v2.1-json-patch'
         headers = self._headers({'content-type': media_type})
+        url = 'http://127.0.0.1:%s/foo_image' % self.http_port0
         data = jsonutils.dumps([{'op': 'replace', 'path': '/locations',
-                                 'value': [{'url': 'file://' + file_path,
-                                            'metadata': {}}]}])
+                                 'value': [{'url': url, 'metadata': {}}]
+                                 }])
         response = requests.patch(path, headers=headers, data=data)
         self.assertEqual(200, response.status_code, response.text)
 
@@ -2195,7 +2197,42 @@ class TestImages(functional.FunctionalTest):
         response = requests.get(path, headers=headers)
         self.assertEqual(200, response.status_code)
         image = jsonutils.loads(response.text)
-        self.assertEqual(image['size'], 6)
+        self.assertEqual(image['size'], 10)
+
+    def test_update_locations_with_restricted_sources(self):
+        self.start_servers(**self.__dict__.copy())
+        # Create an image
+        path = self._url('/v2/images')
+        headers = self._headers({'content-type': 'application/json'})
+        data = jsonutils.dumps({'name': 'image-1', 'disk_format': 'aki',
+                                'container_format': 'aki'})
+        response = requests.post(path, headers=headers, data=data)
+        self.assertEqual(201, response.status_code)
+
+        # Returned image entity should have a generated id and status
+        image = jsonutils.loads(response.text)
+        image_id = image['id']
+        self.assertEqual('queued', image['status'])
+        self.assertNotIn('size', image)
+        self.assertNotIn('virtual_size', image)
+
+        # Update locations for the queued image
+        path = self._url('/v2/images/%s' % image_id)
+        media_type = 'application/openstack-images-v2.1-json-patch'
+        headers = self._headers({'content-type': media_type})
+        data = jsonutils.dumps([{'op': 'replace', 'path': '/locations',
+                                 'value': [{'url': 'file:///foo_image',
+                                            'metadata': {}}]
+                                 }])
+        response = requests.patch(path, headers=headers, data=data)
+        self.assertEqual(400, response.status_code, response.text)
+
+        data = jsonutils.dumps([{'op': 'replace', 'path': '/locations',
+                                 'value': [{'url': 'swift+config:///foo_image',
+                                            'metadata': {}}]
+                                 }])
+        response = requests.patch(path, headers=headers, data=data)
+        self.assertEqual(400, response.status_code, response.text)
 
 
 class TestImagesWithRegistry(TestImages):
@@ -2421,16 +2458,16 @@ class TestImageLocationSelectionStrategy(functional.FunctionalTest):
         super(TestImageLocationSelectionStrategy, self).setUp()
         self.cleanup()
         self.api_server.deployment_flavor = 'noauth'
-        self.foo_image_file = tempfile.NamedTemporaryFile()
-        self.foo_image_file.write("foo image file")
-        self.foo_image_file.flush()
-        self.addCleanup(self.foo_image_file.close)
-        ret = http_server("foo_image_id", "foo_image")
-        self.http_server_pid, self.http_port = ret
+        for i in range(3):
+            ret = http_server("foo_image_id%d" % i, "foo_image%d" % i)
+            setattr(self, 'http_server%d_pid' % i, ret[0])
+            setattr(self, 'http_port%d' % i, ret[1])
 
     def tearDown(self):
-        if self.http_server_pid is not None:
-            os.kill(self.http_server_pid, signal.SIGKILL)
+        for i in range(3):
+            pid = getattr(self, 'http_server%d_pid' % i, None)
+            if pid:
+                os.kill(pid, signal.SIGKILL)
 
         super(TestImageLocationSelectionStrategy, self).tearDown()
 
@@ -2483,77 +2520,16 @@ class TestImageLocationSelectionStrategy(functional.FunctionalTest):
         path = self._url('/v2/images/%s' % image_id)
         media_type = 'application/openstack-images-v2.1-json-patch'
         headers = self._headers({'content-type': media_type})
-        values = [{'url': 'file://%s' % self.foo_image_file.name,
-                   'metadata': {'idx': '1'}},
-                  {'url': 'http://127.0.0.1:%s/foo_image' % self.http_port,
-                   'metadata': {'idx': '0'}}]
+        values = [{'url': 'http://127.0.0.1:%s/foo_image' % self.http_port0,
+                   'metadata': {}},
+                  {'url': 'http://127.0.0.1:%s/foo_image' % self.http_port1,
+                   'metadata': {}}]
         doc = [{'op': 'replace',
                 'path': '/locations',
                 'value': values}]
         data = jsonutils.dumps(doc)
         response = requests.patch(path, headers=headers, data=data)
         self.assertEqual(200, response.status_code)
-
-        # Image locations should be visible
-        path = self._url('/v2/images/%s' % image_id)
-        headers = self._headers({'Content-Type': 'application/json'})
-        response = requests.get(path, headers=headers)
-        self.assertEqual(200, response.status_code)
-        image = jsonutils.loads(response.text)
-        self.assertTrue('locations' in image)
-        self.assertEqual(image['locations'], values)
-        self.assertTrue('direct_url' in image)
-        self.assertEqual(image['direct_url'], values[0]['url'])
-
-        self.stop_servers()
-
-    def test_image_locatons_with_store_type_strategy(self):
-        self.api_server.show_image_direct_url = True
-        self.api_server.show_multiple_locations = True
-        self.image_location_quota = 10
-        self.api_server.location_strategy = 'store_type'
-        preference = "http, swift, filesystem"
-        self.api_server.store_type_location_strategy_preference = preference
-        self.start_servers(**self.__dict__.copy())
-
-        # Create an image
-        path = self._url('/v2/images')
-        headers = self._headers({'content-type': 'application/json'})
-        data = jsonutils.dumps({'name': 'image-1', 'type': 'kernel',
-                                'foo': 'bar', 'disk_format': 'aki',
-                                'container_format': 'aki'})
-        response = requests.post(path, headers=headers, data=data)
-        self.assertEqual(201, response.status_code)
-
-        # Get the image id
-        image = jsonutils.loads(response.text)
-        image_id = image['id']
-
-        # Image locations should not be visible before location is set
-        path = self._url('/v2/images/%s' % image_id)
-        headers = self._headers({'Content-Type': 'application/json'})
-        response = requests.get(path, headers=headers)
-        self.assertEqual(200, response.status_code)
-        image = jsonutils.loads(response.text)
-        self.assertTrue('locations' in image)
-        self.assertTrue(image["locations"] == [])
-
-        # Update image locations via PATCH
-        path = self._url('/v2/images/%s' % image_id)
-        media_type = 'application/openstack-images-v2.1-json-patch'
-        headers = self._headers({'content-type': media_type})
-        values = [{'url': 'file://%s' % self.foo_image_file.name,
-                   'metadata': {'idx': '1'}},
-                  {'url': 'http://127.0.0.1:%s/foo_image' % self.http_port,
-                   'metadata': {'idx': '0'}}]
-        doc = [{'op': 'replace',
-                'path': '/locations',
-                'value': values}]
-        data = jsonutils.dumps(doc)
-        response = requests.patch(path, headers=headers, data=data)
-        self.assertEqual(200, response.status_code)
-
-        values.sort(key=lambda loc: int(loc['metadata']['idx']))
 
         # Image locations should be visible
         path = self._url('/v2/images/%s' % image_id)

--- a/glance/tests/unit/test_store_image.py
+++ b/glance/tests/unit/test_store_image.py
@@ -18,6 +18,7 @@ import glance_store
 
 from glance.common import exception
 import glance.location
+from glance.tests.unit import base as unit_test_base
 from glance.tests.unit import utils as unit_test_utils
 from glance.tests import utils
 
@@ -759,7 +760,7 @@ class TestStoreImageRepo(utils.BaseTestCase):
         self.assertEqual(acls['read'], [TENANT2])
 
 
-class TestImageFactory(utils.BaseTestCase):
+class TestImageFactory(unit_test_base.StoreClearingUnitTest):
 
     def setUp(self):
         super(TestImageFactory, self).setUp()

--- a/glance/tests/unit/test_store_location.py
+++ b/glance/tests/unit/test_store_location.py
@@ -69,12 +69,15 @@ class TestStoreLocation(base.StoreClearingUnitTest):
 
         loc1 = {'url': 'file:///fake1.img.tar.gz', 'metadata': {}}
         loc2 = {'url': 'swift+config:///xxx', 'metadata': {}}
+        loc3 = {'url': 'filesystem:///foo.img.tar.gz', 'metadata': {}}
 
         # Test for insert location
         image1 = TestStoreLocation.FakeImageProxy()
         locations = glance.location.StoreLocations(image1, [])
         self.assertRaises(exception.BadStoreUri, locations.insert, 0, loc1)
+        self.assertRaises(exception.BadStoreUri, locations.insert, 0, loc3)
         self.assertNotIn(loc1, locations)
+        self.assertNotIn(loc3, locations)
 
         # Test for set_attr of _locations_proxy
         image2 = TestStoreLocation.FakeImageProxy()

--- a/glance/tests/unit/utils.py
+++ b/glance/tests/unit/utils.py
@@ -14,12 +14,13 @@
 #    under the License.
 
 import urllib
-import urlparse
 
 import glance_store as store
 from oslo.config import cfg
+import six.moves.urllib.parse as urlparse
 
 from glance.common import exception
+from glance.common import store_utils
 from glance.common import wsgi
 import glance.context
 import glance.db.simple.api as simple_db
@@ -134,6 +135,12 @@ class FakeStoreUtils(object):
                                                       location)
         else:
             self.safe_delete_from_backend(context, image_id, location)
+
+    def validate_external_location(self, uri):
+        if uri and urlparse.urlparse(uri).scheme:
+            return store_utils.validate_external_location(uri)
+        else:
+            return True
 
 
 class FakeStoreAPI(object):

--- a/glance/tests/unit/v1/test_api.py
+++ b/glance/tests/unit/v1/test_api.py
@@ -1071,31 +1071,23 @@ class TestGlanceAPI(base.IsolatedUnitTest):
 
     def test_add_copy_from_with_restricted_sources(self):
         """Tests creates an image from copy-from with restricted sources"""
-        fixture_headers = {'x-image-meta-store': 'file',
+        header_template = {'x-image-meta-store': 'file',
                            'x-image-meta-disk-format': 'vhd',
-                           'x-glance-api-copy-from': 'file:///etc/passwd',
                            'x-image-meta-container-format': 'ovf',
                            'x-image-meta-name': 'fake image #F'}
 
-        req = webob.Request.blank("/images")
-        req.method = 'POST'
-        for k, v in six.iteritems(fixture_headers):
-            req.headers[k] = v
-        res = req.get_response(self.api)
-        self.assertEqual(400, res.status_int)
+        schemas = ["file:///etc/passwd",
+                   "swift+config:///xxx",
+                   "filesystem:///etc/passwd"]
 
-        fixture_headers = {'x-image-meta-store': 'file',
-                           'x-image-meta-disk-format': 'vhd',
-                           'x-glance-api-copy-from': 'swift+config://xxx',
-                           'x-image-meta-container-format': 'ovf',
-                           'x-image-meta-name': 'fake image #F'}
-
-        req = webob.Request.blank("/images")
-        req.method = 'POST'
-        for k, v in six.iteritems(fixture_headers):
-            req.headers[k] = v
-        res = req.get_response(self.api)
-        self.assertEqual(400, res.status_int)
+        for schema in schemas:
+            req = webob.Request.blank("/images")
+            req.method = 'POST'
+            for k, v in six.iteritems(header_template):
+                req.headers[k] = v
+            req.headers['x-glance-api-copy-from'] = schema
+            res = req.get_response(self.api)
+            self.assertEqual(400, res.status_int)
 
     def test_add_copy_from_upload_image_unauthorized_with_body(self):
         rules = {"upload_image": '!', "modify_image": '@',

--- a/glance/tests/unit/v1/test_api.py
+++ b/glance/tests/unit/v1/test_api.py
@@ -419,7 +419,7 @@ class TestGlanceAPI(base.IsolatedUnitTest):
 
         res = req.get_response(self.api)
         self.assertEqual(res.status_int, 400)
-        self.assertIn('External sourcing not supported', res.body)
+        self.assertIn('External source are not supported', res.body)
 
     def test_create_with_location_bad_store_uri(self):
         fixture_headers = {
@@ -1006,7 +1006,7 @@ class TestGlanceAPI(base.IsolatedUnitTest):
             res = req.get_response(self.api)
             self.assertEqual(res.status_int, 409)
 
-    def test_add_location_with_invalid_location(self):
+    def test_add_location_with_invalid_location_on_conflict_image_size(self):
         """Tests creates an image from location and conflict image size"""
         fixture_headers = {'x-image-meta-store': 'file',
                            'x-image-meta-disk-format': 'vhd',
@@ -1023,6 +1023,36 @@ class TestGlanceAPI(base.IsolatedUnitTest):
         res = req.get_response(self.api)
         self.assertEqual(res.status_int, 400)
 
+    def test_add_location_with_invalid_location_on_restricted_sources(self):
+        """Tests creates an image from location and restricted sources"""
+        fixture_headers = {'x-image-meta-store': 'file',
+                           'x-image-meta-disk-format': 'vhd',
+                           'x-image-meta-location': 'file:///etc/passwd',
+                           'x-image-meta-container-format': 'ovf',
+                           'x-image-meta-name': 'fake image #F'}
+
+        req = webob.Request.blank("/images")
+        req.headers['Content-Type'] = 'application/octet-stream'
+        req.method = 'POST'
+        for k, v in fixture_headers.iteritems():
+            req.headers[k] = v
+        res = req.get_response(self.api)
+        self.assertEqual(400, res.status_int)
+
+        fixture_headers = {'x-image-meta-store': 'file',
+                           'x-image-meta-disk-format': 'vhd',
+                           'x-image-meta-location': 'swift+config://xxx',
+                           'x-image-meta-container-format': 'ovf',
+                           'x-image-meta-name': 'fake image #F'}
+
+        req = webob.Request.blank("/images")
+        req.headers['Content-Type'] = 'application/octet-stream'
+        req.method = 'POST'
+        for k, v in fixture_headers.iteritems():
+            req.headers[k] = v
+        res = req.get_response(self.api)
+        self.assertEqual(400, res.status_int)
+
     def test_add_copy_from_with_location(self):
         """Tests creates an image from copy-from and location"""
         fixture_headers = {'x-image-meta-store': 'file',
@@ -1038,6 +1068,34 @@ class TestGlanceAPI(base.IsolatedUnitTest):
             req.headers[k] = v
         res = req.get_response(self.api)
         self.assertEqual(res.status_int, 400)
+
+    def test_add_copy_from_with_restricted_sources(self):
+        """Tests creates an image from copy-from with restricted sources"""
+        fixture_headers = {'x-image-meta-store': 'file',
+                           'x-image-meta-disk-format': 'vhd',
+                           'x-glance-api-copy-from': 'file:///etc/passwd',
+                           'x-image-meta-container-format': 'ovf',
+                           'x-image-meta-name': 'fake image #F'}
+
+        req = webob.Request.blank("/images")
+        req.method = 'POST'
+        for k, v in six.iteritems(fixture_headers):
+            req.headers[k] = v
+        res = req.get_response(self.api)
+        self.assertEqual(400, res.status_int)
+
+        fixture_headers = {'x-image-meta-store': 'file',
+                           'x-image-meta-disk-format': 'vhd',
+                           'x-glance-api-copy-from': 'swift+config://xxx',
+                           'x-image-meta-container-format': 'ovf',
+                           'x-image-meta-name': 'fake image #F'}
+
+        req = webob.Request.blank("/images")
+        req.method = 'POST'
+        for k, v in six.iteritems(fixture_headers):
+            req.headers[k] = v
+        res = req.get_response(self.api)
+        self.assertEqual(400, res.status_int)
 
     def test_add_copy_from_upload_image_unauthorized_with_body(self):
         rules = {"upload_image": '!', "modify_image": '@',

--- a/glance/version.py
+++ b/glance/version.py
@@ -13,6 +13,31 @@
 #    under the License.
 
 
-import pbr.version
+GLANCE_VENDOR = "OpenStack Foundation"
+GLANCE_PRODUCT = "OpenStack Glance"
+GLANCE_PACKAGE = None  # OS distro package version suffix
 
-version_info = pbr.version.VersionInfo('glance')
+loaded = False
+
+
+class VersionInfo(object):
+    release = "REDHATGLANCERELEASE"
+    version = "REDHATGLANCEVERSION"
+
+    def version_string(self):
+        return self.version
+
+    def cached_version_string(self):
+        return self.version
+
+    def release_string(self):
+        return self.release
+
+    def canonical_version_string(self):
+        return self.version
+
+    def version_string_with_vcs(self):
+        return self.release
+
+
+version_info = VersionInfo()


### PR DESCRIPTION
- 0001-Don-t-access-the-net-while-building-docs.patch
- 0002-Remove-runtime-dep-on-python-pbr.patch
- 0003-avoid-unsupported-storage-drivers.patch
- 0004-notify-calling-process-we-are-ready-to-serve.patch
- 0005-To-prevent-client-use-v2-patch-api-to-handle-file-an.patch
- 0006-Prevent-file-swift-config-and-filesystem-schemes.patch
